### PR TITLE
feat: add packaging status badge for koala-clash in release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,6 +102,9 @@ jobs:
           <a href="https://github.com/coolcoala/clash-verge-rev-lite/releases/download/v${{ env.VERSION }}/Koala.Clash_armhf.deb"><img src="https://img.shields.io/badge/armhf-default?style=flat&logo=debian&label=DEB"> </a><br>
           <a href="https://github.com/coolcoala/clash-verge-rev-lite/releases/download/v${{ env.VERSION }}/Koala.Clash.armhfp.rpm"><img src="https://img.shields.io/badge/armhfp-default?style=flat&logo=fedora&label=RPM"> </a>
 
+          #### Package availability for many distributions
+          [![Packaging status](https://repology.org/badge/vertical-allrepos/koala-clash.svg)](https://repology.org/project/koala-clash/versions)
+
           ### Windows (Win7 is no longer supported)
           #### Normal version (recommended)
           <a href="https://github.com/coolcoala/clash-verge-rev-lite/releases/download/v${{ env.VERSION }}/Koala.Clash_x64-setup.exe"><img src="https://badgen.net/badge/icon/x64?icon=windows&label=exe"></a><br>


### PR DESCRIPTION
This pull request introduces an informational enhancement to the release workflow by adding a visual badge and link that display package availability across many Linux distributions.

Documentation and visibility improvements:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R105-R107): Added a Repology badge and link to indicate packaging status and availability for `koala-clash` across multiple distributions, improving visibility for users seeking distribution-specific packages.