### PR TITLE
Fix routing rule order mismatch between editor, list view, and runtim…

### DIFF
--- a/src/main/core/factory.ts
+++ b/src/main/core/factory.ts
@@ -52,6 +52,11 @@ function processRulesWithOffset(ruleStrings: string[], currentRules: string[], i
   return { normalRules, insertRules: rules }
 }
 
+function getDefaultAppendInsertPosition(rules: string[]): number {
+  const matchIndex = rules.findLastIndex((rule) => rule.split(',')[0]?.trim() === 'MATCH')
+  return matchIndex === -1 ? rules.length : matchIndex
+}
+
 export async function generateProfile(): Promise<void> {
   const { current } = await getProfileConfig()
   const {
@@ -111,7 +116,11 @@ export async function generateProfile(): Promise<void> {
           rules,
           true
         )
-        rules = [...insertRules, ...appendRules]
+        rules = [...insertRules]
+        appendRules.forEach((rule) => {
+          const insertPosition = getDefaultAppendInsertPosition(rules)
+          rules.splice(insertPosition, 0, rule)
+        })
       }
 
       // 处理删除规则

--- a/src/renderer/src/components/profiles/edit-rules-modal.tsx
+++ b/src/renderer/src/components/profiles/edit-rules-modal.tsx
@@ -211,6 +211,11 @@ const parseRuleStringToItem = (ruleStr: string): RuleItem => {
   }
 }
 
+const getDefaultAppendInsertPosition = (rules: RuleItem[]): number => {
+  const matchIndex = rules.findLastIndex((rule) => rule.type === 'MATCH')
+  return matchIndex === -1 ? rules.length : matchIndex
+}
+
 const domainValidator = (value: string): boolean => {
   if (value.length > 253 || value.length < 2) return false
 
@@ -1223,7 +1228,7 @@ const EditRulesModal: React.FC<Props> = (props) => {
                   if (rule.offset !== undefined) {
                     return Math.max(0, currentRules.length - rule.offset)
                   }
-                  return currentRules.length
+                  return getDefaultAppendInsertPosition(currentRules)
                 }
               )
 
@@ -1357,10 +1362,12 @@ const EditRulesModal: React.FC<Props> = (props) => {
       // 保存规则到文件
       const prependRuleStrings = Array.from(prependRules)
         .filter((index) => !deletedRules.has(index) && index < rules.length)
+        .sort((left, right) => left - right)
         .map((index) => convertRuleToString(rules[index]))
 
       const appendRuleStrings = Array.from(appendRules)
         .filter((index) => !deletedRules.has(index) && index < rules.length)
+        .sort((left, right) => left - right)
         .map((index) => convertRuleToString(rules[index]))
 
       // 保存删除的规则


### PR DESCRIPTION
This PR fixes a routing rule ordering bug where the order shown in the rule editor could diverge from the order shown on the rules list page and from the actual order used by the runtime.
The root cause was inconsistent handling of appended custom rules. In the editor, regular appended rules were inserted before the final **_MATCH_** rule, but when loading saved rule overrides and when generating the runtime config, they could end up in a different position. In addition, saved custom **_prepend_** and **_append_** rules were serialized without preserving their current visual order after drag-and-drop.
Changes in this PR:

- unify append rule placement so default appended rules are restored and applied before the final **_MATCH_** rule in both the editor and runtime config generation
- preserve the current visual order of custom **_prepend_** and **_append_** rules when saving rule overrides
- keep the rule editor, runtime-applied rule order, and rules list view consistent
- Validation:
- installed project dependencies
- run **_npm run typecheck_** successfully

Suggested title: **_Fix routing rule order mismatch between editor, list view, and runtime_**