### PR TITLE
Fix stuck system proxy cleanup after VPN traffic drops offline

### DIFF
--- a/src/main/sys/sysproxy.ts
+++ b/src/main/sys/sysproxy.ts
@@ -11,14 +11,19 @@ let defaultBypass: string[]
 let triggerSysProxyTimer: NodeJS.Timeout | null = null
 
 export async function triggerSysProxy(enable: boolean, onlyActiveDevice: boolean): Promise<void> {
+  if (triggerSysProxyTimer) {
+    clearTimeout(triggerSysProxyTimer)
+    triggerSysProxyTimer = null
+  }
+
+  if (!enable) {
+    await disableSysProxy(onlyActiveDevice)
+    return
+  }
+
   if (net.isOnline()) {
-    if (enable) {
-      await setSysProxy(onlyActiveDevice)
-    } else {
-      await disableSysProxy(onlyActiveDevice)
-    }
+    await setSysProxy(onlyActiveDevice)
   } else {
-    if (triggerSysProxyTimer) clearTimeout(triggerSysProxyTimer)
     triggerSysProxyTimer = setTimeout(() => triggerSysProxy(enable, onlyActiveDevice), 5000)
   }
 }


### PR DESCRIPTION
### Summary
This PR fixes a case where system proxy cleanup could be skipped when the app detected the network as offline.

Previously, `triggerSysProxy(false, ...)` was gated by `electron.net.isOnline()`. If the VPN/proxy path had already broken and Electron reported `offline`, disabling System Proxy from the UI did not immediately clear the OS proxy settings. As a result, the app could show proxy/VPN as disabled while the operating system still routed traffic through a stale local proxy endpoint.

### What changed
- Clear any pending delayed `triggerSysProxy` retry before applying a new proxy action.
- Run proxy disable immediately when `enable === false`, even if Electron reports the network as offline.
- Keep delayed retry behavior only for proxy enable, where waiting for connectivity still makes sense.

### Why this matters
This makes proxy cleanup more predictable in degraded network conditions and helps avoid leaving the system stuck with an invalid proxy configuration after the user turns System Proxy off.

### Scope
This change is limited to `src/main/sys/sysproxy.ts` and does not alter normal proxy setup behavior while the network is online.

---

### Описание
Этот PR исправляет сценарий, в котором очистка системного прокси могла не выполниться, если приложение уже считало сеть `offline`.

Раньше `triggerSysProxy(false, ...)` зависел от `electron.net.isOnline()`. Если VPN/прокси-маршрут уже сломался и Electron сообщал `offline`, выключение System Proxy из интерфейса не снимало прокси-настройки ОС сразу. В результате приложение могло показывать, что прокси/VPN выключен, хотя операционная система продолжала отправлять трафик в устаревший локальный прокси.

### Что изменилось
- Очищается любой отложенный retry `triggerSysProxy` перед выполнением нового действия с прокси.
- При `enable === false` отключение прокси выполняется сразу, даже если Electron считает сеть offline.
- Поведение с отложенным retry сохраняется только для включения прокси, где ожидание восстановления сети действительно имеет смысл.

### Зачем это нужно
Это делает очистку системного прокси более предсказуемой в деградировавших сетевых состояниях и помогает избежать ситуации, когда после выключения System Proxy система остаётся с невалидной прокси-конфигурацией.

### Область изменений
Изменение ограничено `src/main/sys/sysproxy.ts` и не меняет обычную логику установки прокси при нормальном online-состоянии сети.