### PR TITLE
Isolate dev instance from installed app

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -56,6 +56,8 @@ let isCreatingWindow = false
 let windowShown = false
 let createWindowPromiseResolve: (() => void) | null = null
 let createWindowPromise: Promise<void> | null = null
+const DEV_RENDERER_LOAD_RETRY_MS = 350
+const DEV_RENDERER_LOAD_MAX_ATTEMPTS = 30
 
 configureDevInstanceIsolation()
 
@@ -463,6 +465,27 @@ function parseFilename(str: string): string {
   }
 }
 
+async function loadRendererWindow(window: BrowserWindow): Promise<void> {
+  const devRendererUrl = process.env['ELECTRON_RENDERER_URL']
+  if (is.dev && devRendererUrl) {
+    let lastError: unknown
+
+    for (let attempt = 1; attempt <= DEV_RENDERER_LOAD_MAX_ATTEMPTS; attempt++) {
+      try {
+        await window.loadURL(devRendererUrl)
+        return
+      } catch (error) {
+        lastError = error
+        await new Promise((resolve) => setTimeout(resolve, DEV_RENDERER_LOAD_RETRY_MS))
+      }
+    }
+
+    throw lastError
+  }
+
+  await window.loadFile(join(__dirname, '../renderer/index.html'))
+}
+
 export async function createWindow(appConfig?: AppConfig): Promise<void> {
   if (isCreatingWindow) {
     if (createWindowPromise) {
@@ -530,8 +553,11 @@ export async function createWindow(appConfig?: AppConfig): Promise<void> {
         await scheduleLightweightMode()
       }
     })
-    mainWindow.webContents.on('did-fail-load', () => {
-      mainWindow?.webContents.reload()
+    mainWindow.webContents.on('did-fail-load', (_event, errorCode, errorDescription, _url, isMainFrame) => {
+      if (!isMainFrame) return
+      if (errorCode === -3) return
+
+      showError(t('dialog.appInitFailed'), `${errorDescription} (${errorCode})`)
     })
 
     mainWindow.webContents.once('did-finish-load', () => {
@@ -578,13 +604,7 @@ export async function createWindow(appConfig?: AppConfig): Promise<void> {
       shell.openExternal(details.url)
       return { action: 'deny' }
     })
-    // HMR for renderer base on electron-vite cli.
-    // Load the remote URL for development or the local html file for production.
-    if (is.dev && process.env['ELECTRON_RENDERER_URL']) {
-      mainWindow.loadURL(process.env['ELECTRON_RENDERER_URL'])
-    } else {
-      mainWindow.loadFile(join(__dirname, '../renderer/index.html'))
-    }
+    await loadRendererWindow(mainWindow)
   } finally {
     isCreatingWindow = false
     if (createWindowPromiseResolve) {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,7 +1,16 @@
 import { electronApp, is, optimizer } from '@electron-toolkit/utils'
 import { registerIpcMainHandlers } from './utils/ipc'
 import windowStateKeeper from 'electron-window-state'
-import { app, BrowserWindow, dialog, ipcMain, Menu, Notification, powerMonitor, shell } from 'electron'
+import {
+  app,
+  BrowserWindow,
+  dialog,
+  ipcMain,
+  Menu,
+  Notification,
+  powerMonitor,
+  shell
+} from 'electron'
 import { addProfileItem, getAppConfig, patchControledMihomoConfig } from './config'
 import { quitWithoutCore, startCore, stopCore } from './core/manager'
 import { triggerSysProxy } from './sys/sysproxy'
@@ -20,10 +29,16 @@ import { showFloatingWindow } from './resolve/floatingWindow'
 import { getAppConfigSync } from './config/app'
 import { t } from './utils/i18n'
 
-
 let quitTimeout: NodeJS.Timeout | null = null
 export let mainWindow: BrowserWindow | null = null
 export let needsFirstRunAdmin = false
+
+function configureDevInstanceIsolation(): void {
+  if (!is.dev) return
+
+  const devUserDataPath = path.join(app.getPath('appData'), 'io.github.koala-clash-dev')
+  app.setPath('userData', devUserDataPath)
+}
 
 /**
  * Show error to the user via renderer toast notification.
@@ -41,6 +56,8 @@ let isCreatingWindow = false
 let windowShown = false
 let createWindowPromiseResolve: (() => void) | null = null
 let createWindowPromise: Promise<void> | null = null
+
+configureDevInstanceIsolation()
 
 async function scheduleLightweightMode(): Promise<void> {
   const {
@@ -105,7 +122,7 @@ if (process.platform === 'win32' && is.dev) {
   patchControledMihomoConfig({ tun: { enable: false } })
 }
 
-const gotTheLock = app.requestSingleInstanceLock()
+const gotTheLock = is.dev ? true : app.requestSingleInstanceLock()
 
 if (!gotTheLock) {
   app.quit()
@@ -277,7 +294,7 @@ powerMonitor.on('shutdown', async () => {
 // Some APIs can only be used after this event occurs.
 app.whenReady().then(async () => {
   // Set app user model id for windows
-  electronApp.setAppUserModelId('koala-clash.app')
+  electronApp.setAppUserModelId(is.dev ? 'koala-clash.app.dev' : 'koala-clash.app')
   try {
     await initPromise
   } catch (e) {

--- a/src/main/utils/dirs.ts
+++ b/src/main/utils/dirs.ts
@@ -9,6 +9,10 @@ import { t } from './i18n'
 
 export const homeDir = app.getPath('home')
 
+function runtimeNamespace(): string {
+  return is.dev ? 'koala-clash-dev' : 'koala-clash'
+}
+
 export function isPortable(): boolean {
   return existsSync(path.join(exeDir(), 'PORTABLE'))
 }
@@ -59,23 +63,23 @@ export function themesDir(): string {
 
 export function mihomoIpcPath(): string {
   if (process.platform === 'win32') {
-    return '\\\\.\\pipe\\Koala-Clash\\mihomo'
+    return `\\\\.\\pipe\\${runtimeNamespace()}\\mihomo`
   }
   const { core = 'mihomo' } = getAppConfigSync()
   if (core === 'system') {
-    return '/tmp/koala-clash-mihomo-external.sock'
+    return `/tmp/${runtimeNamespace()}-mihomo-external.sock`
   }
   if (!checkCorePermissionSync(core as 'mihomo' | 'mihomo-alpha')) {
-    return '/tmp/koala-clash-mihomo-api-noperm.sock'
+    return `/tmp/${runtimeNamespace()}-mihomo-api-noperm.sock`
   }
-  return '/tmp/koala-clash-mihomo-api.sock'
+  return `/tmp/${runtimeNamespace()}-mihomo-api.sock`
 }
 
 export function serviceIpcPath(): string {
   if (process.platform === 'win32') {
-    return '\\\\.\\pipe\\sparkle\\service'
+    return `\\\\.\\pipe\\sparkle\\${runtimeNamespace()}-service`
   }
-  return '/tmp/sparkle-service.sock'
+  return `/tmp/${runtimeNamespace()}-service.sock`
 }
 
 export function mihomoCoreDir(): string {
@@ -90,7 +94,9 @@ export function mihomoCorePath(core: string): string {
   if (core === 'system') {
     const sysPath = systemCorePath()
     if (!sysPath || !existsSync(sysPath)) {
-      const errorMsg = sysPath ? `${t('error.systemCorePathInvalid')}: ${sysPath}` : t('error.systemCorePathNotSet')
+      const errorMsg = sysPath
+        ? `${t('error.systemCorePathInvalid')}: ${sysPath}`
+        : t('error.systemCorePathNotSet')
       throw new Error(errorMsg)
     }
     return sysPath


### PR DESCRIPTION
This PR is not intended to support full parallel usage of the release app and the dev build as two independent working runtimes.

Its goal is narrower: when developing locally on a machine that already has Koala Clash installed, the dev build should not reuse the installed app's local state and process identity.

### Problem

During local development, the dev build currently shares parts of its app identity with the installed app, including:

- single-instance lock
- `userData` directory
- IPC / socket / pipe namespace

Because of that, starting the dev build may interact with the installed copy instead of behaving like an isolated development environment.

### What this PR changes

Only in `dev` mode:

- use a separate `userData` directory
- use separate IPC / socket / pipe paths
- use a separate Windows App User Model ID
- avoid production single-instance behavior in dev, so the dev process does not attach to an already running installed instance

### Non-goals

This PR does not aim to make two full app runtimes safe for simultaneous end-user operation.

It does not claim to solve possible conflicts at the core / proxy / port level if both versions are actively used at the same time.

### Why this is useful

This makes local development safer on machines where the release version is already installed:

- dev does not touch release app data
- dev does not reuse release process identity
- local testing is isolated from the installed copy

---

Этот PR не предназначен для поддержки полноценного параллельного использования релизной и dev версии как двух независимых рабочих runtime-инстансов.

Его цель более узкая: при локальной разработке на машине, где Koala Clash уже установлен, dev-сборка не должна использовать локальное состояние и process identity установленной версии.

### Проблема

Во время локальной разработки dev-сборка сейчас разделяет с установленной версией часть своей идентичности приложения, в том числе:

- single-instance lock
- каталог `userData`
- namespace для IPC / socket / pipe

Из-за этого при запуске dev-сборка может взаимодействовать с установленной копией вместо того, чтобы работать как изолированная среда разработки.

### Что меняет этот PR

Только в режиме `dev`:

- используется отдельный каталог `userData`
- используются отдельные пути IPC / socket / pipe
- используется отдельный Windows App User Model ID
- отключается production-поведение single-instance в dev, чтобы dev-процесс не подключался к уже запущенному установленному экземпляру

### Что этот PR не делает

Этот PR не ставит целью сделать два полноценных runtime-инстанса безопасными для одновременного пользовательского использования.

Он не заявляет, что решает возможные конфликты на уровне core / proxy / портов, если обе версии активно используются одновременно.

### Зачем это нужно

Это делает локальную разработку безопаснее на машинах, где уже установлена релизная версия:

- dev не затрагивает данные релизной версии
- dev не использует process identity релизной версии
- локальное тестирование изолировано от установленной копии