### PR TITLE
Fix white window after renderer idle failure

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -41,6 +41,41 @@ let isCreatingWindow = false
 let windowShown = false
 let createWindowPromiseResolve: (() => void) | null = null
 let createWindowPromise: Promise<void> | null = null
+let mainWindowRecoveryTimeout: NodeJS.Timeout | null = null
+
+function scheduleMainWindowRecovery(reason: string): void {
+  if (!mainWindow || mainWindow.isDestroyed() || mainWindowRecoveryTimeout) {
+    return
+  }
+
+  mainWindowRecoveryTimeout = setTimeout(() => {
+    const currentWindow = mainWindow
+
+    if (!currentWindow || currentWindow.isDestroyed()) {
+      mainWindowRecoveryTimeout = null
+      return
+    }
+
+    console.error(`[main-window] Recovering renderer after ${reason}`)
+
+    if (currentWindow.webContents.isDestroyed()) {
+      currentWindow.destroy()
+      mainWindow = null
+      void createWindow().then(() => {
+        if (windowShown) {
+          void showMainWindow()
+        }
+      })
+    } else {
+      currentWindow.webContents.reloadIgnoringCache()
+      if (windowShown && !currentWindow.isVisible()) {
+        currentWindow.show()
+      }
+    }
+
+    mainWindowRecoveryTimeout = null
+  }, 300)
+}
 
 async function scheduleLightweightMode(): Promise<void> {
   const {
@@ -513,8 +548,22 @@ export async function createWindow(appConfig?: AppConfig): Promise<void> {
         await scheduleLightweightMode()
       }
     })
-    mainWindow.webContents.on('did-fail-load', () => {
-      mainWindow?.webContents.reload()
+    mainWindow.on('unresponsive', () => {
+      scheduleMainWindowRecovery('window-unresponsive')
+    })
+    mainWindow.webContents.on('did-fail-load', (_event, errorCode, errorDescription, _url, isMainFrame) => {
+      if (!isMainFrame) {
+        return
+      }
+
+      scheduleMainWindowRecovery(`did-fail-load (${errorCode}: ${errorDescription})`)
+    })
+    mainWindow.webContents.on('render-process-gone', (_event, details) => {
+      if (details.reason === 'clean-exit') {
+        return
+      }
+
+      scheduleMainWindowRecovery(`render-process-gone (${details.reason})`)
     })
 
     mainWindow.webContents.once('did-finish-load', () => {
@@ -526,7 +575,6 @@ export async function createWindow(appConfig?: AppConfig): Promise<void> {
         }, 500)
       }
     })
-
     mainWindow.on('close', async (event) => {
       event.preventDefault()
       mainWindow?.hide()
@@ -536,6 +584,10 @@ export async function createWindow(appConfig?: AppConfig): Promise<void> {
     })
 
     mainWindow.on('closed', () => {
+      if (mainWindowRecoveryTimeout) {
+        clearTimeout(mainWindowRecoveryTimeout)
+        mainWindowRecoveryTimeout = null
+      }
       mainWindow = null
     })
 


### PR DESCRIPTION
## What This Fixes

This PR fixes an issue where, after the app had been running for a long time, opening the main window could sometimes show a completely white screen with no UI and no close/minimize/maximize controls.

## Root Cause

The main window is frameless, and the window controls are rendered by the renderer process. If the renderer became unresponsive or was terminated after a long idle/runtime period, Electron could leave the app showing an empty white window. Previously, the app only attempted recovery on `did-fail-load`, which does not cover all renderer failure scenarios.

## Changes

- added main window recovery when the window becomes `unresponsive`
- added recovery when `render-process-gone` is triggered
- restricted `did-fail-load` recovery to the main frame only
- recreate the window if `webContents` has already been destroyed
- clear the recovery timer when the window is closed

## Result

If the renderer hangs or gets terminated after a long runtime, the app now attempts to recover the main window automatically instead of leaving the user with a blank white frameless window.

## Verification

- `npm.cmd run typecheck`