### PR TITLE
Add UI for editing Mihomo proxy group behavior

### DIFF
--- a/src/main/config/proxyGroup.ts
+++ b/src/main/config/proxyGroup.ts
@@ -1,0 +1,183 @@
+import { getProfile, getProfileConfig, setProfileStr } from './profile'
+import { stringifyYaml } from '../utils/yaml'
+
+const BUILTIN_PROXY_CANDIDATES = ['DIRECT']
+const RAW_TO_EDITABLE_GROUP_TYPE: Record<string, EditableProxyGroupType> = {
+  select: 'Selector',
+  selector: 'Selector',
+  fallback: 'Fallback',
+  'url-test': 'URLTest',
+  urltest: 'URLTest'
+}
+const EDITABLE_TO_RAW_GROUP_TYPE: Record<EditableProxyGroupType, string> = {
+  Selector: 'select',
+  Fallback: 'fallback',
+  URLTest: 'url-test'
+}
+
+interface MihomoNamedProxy {
+  name?: string
+}
+
+interface MihomoProxyGroupRecord {
+  name?: string
+  type?: string
+  proxies?: string[]
+  use?: string[]
+  url?: string
+  interval?: number
+  timeout?: number
+  lazy?: boolean
+  'max-failed-times'?: number
+  tolerance?: number
+  'expected-status'?: string
+  [key: string]: unknown
+}
+
+function isNamedProxy(proxy: unknown): proxy is MihomoNamedProxy {
+  return !!proxy && typeof proxy === 'object' && 'name' in proxy && typeof proxy.name === 'string'
+}
+
+function isProxyGroupRecord(group: unknown): group is MihomoProxyGroupRecord {
+  return !!group && typeof group === 'object' && 'name' in group && typeof group.name === 'string'
+}
+
+function getStringArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === 'string' && item.trim().length > 0)
+    : []
+}
+
+function getUniqueStrings(values: string[]): string[] {
+  return [...new Set(values.map((value) => value.trim()).filter((value) => value.length > 0))]
+}
+
+function parseGroupType(value: unknown): EditableProxyGroupType {
+  if (typeof value !== 'string') return 'Selector'
+  return RAW_TO_EDITABLE_GROUP_TYPE[value.toLowerCase()] ?? 'Selector'
+}
+
+function isEditableGroupType(value: unknown): boolean {
+  return typeof value === 'string' && value.toLowerCase() in RAW_TO_EDITABLE_GROUP_TYPE
+}
+
+function toOptionalPositiveNumber(value: number | undefined): number | undefined {
+  if (typeof value !== 'number' || Number.isNaN(value) || value < 0) {
+    return undefined
+  }
+  return Math.trunc(value)
+}
+
+export async function getEditableCurrentProfileProxyGroups(): Promise<EditableProxyGroupConfig[]> {
+  const { current } = await getProfileConfig()
+  const profile = await getProfile(current)
+  const rawProxies = Array.isArray(profile.proxies) ? (profile.proxies as unknown[]) : []
+  const rawProxyGroups = Array.isArray(profile['proxy-groups'])
+    ? (profile['proxy-groups'] as unknown[])
+    : []
+  const proxyNames = getUniqueStrings(
+    rawProxies.filter(isNamedProxy).map((proxy) => proxy.name!)
+  )
+
+  const proxyGroups = rawProxyGroups.filter(isProxyGroupRecord)
+  const groupNames = getUniqueStrings(proxyGroups.map((group) => group.name!))
+
+  return proxyGroups
+    .filter((group) => isEditableGroupType(group.type))
+    .map((group) => {
+      const proxies = getStringArray(group.proxies)
+      const providers = getStringArray(group.use)
+
+      return {
+        name: group.name!,
+        type: parseGroupType(group.type),
+        proxies,
+        candidates: getUniqueStrings(
+          proxies.concat(proxyNames, groupNames.filter((name) => name !== group.name), BUILTIN_PROXY_CANDIDATES)
+        ),
+        usesProviders: providers.length > 0,
+        providerOnly: providers.length > 0 && proxies.length === 0,
+        providers,
+        url: typeof group.url === 'string' ? group.url : undefined,
+        interval: typeof group.interval === 'number' ? group.interval : undefined,
+        timeout: typeof group.timeout === 'number' ? group.timeout : undefined,
+        lazy: typeof group.lazy === 'boolean' ? group.lazy : undefined,
+        maxFailedTimes:
+          typeof group['max-failed-times'] === 'number' ? group['max-failed-times'] : undefined,
+        tolerance: typeof group.tolerance === 'number' ? group.tolerance : undefined,
+        expectedStatus:
+          typeof group['expected-status'] === 'string' ? group['expected-status'] : undefined
+      }
+    })
+}
+
+export async function updateCurrentProfileProxyGroup(
+  patch: EditableProxyGroupPatch
+): Promise<void> {
+  const { current } = await getProfileConfig()
+  const profile = await getProfile(current)
+  const rawProxyGroups = Array.isArray(profile['proxy-groups'])
+    ? (profile['proxy-groups'] as unknown[])
+    : []
+  const proxyGroups = rawProxyGroups.filter(isProxyGroupRecord)
+  const groupIndex = proxyGroups.findIndex((group) => group.name === patch.name)
+
+  if (groupIndex === -1) {
+    throw new Error(`Proxy group "${patch.name}" not found`)
+  }
+
+  const targetGroup = proxyGroups[groupIndex]
+  targetGroup.type = EDITABLE_TO_RAW_GROUP_TYPE[patch.type]
+  targetGroup.proxies = getUniqueStrings(patch.proxies)
+
+  const url = patch.url?.trim()
+  if (url) {
+    targetGroup.url = url
+  } else {
+    delete targetGroup.url
+  }
+
+  const interval = toOptionalPositiveNumber(patch.interval)
+  if (interval !== undefined) {
+    targetGroup.interval = interval
+  } else {
+    delete targetGroup.interval
+  }
+
+  const timeout = toOptionalPositiveNumber(patch.timeout)
+  if (timeout !== undefined) {
+    targetGroup.timeout = timeout
+  } else {
+    delete targetGroup.timeout
+  }
+
+  if (typeof patch.lazy === 'boolean') {
+    targetGroup.lazy = patch.lazy
+  } else {
+    delete targetGroup.lazy
+  }
+
+  const maxFailedTimes = toOptionalPositiveNumber(patch.maxFailedTimes)
+  if (maxFailedTimes !== undefined) {
+    targetGroup['max-failed-times'] = maxFailedTimes
+  } else {
+    delete targetGroup['max-failed-times']
+  }
+
+  const tolerance = toOptionalPositiveNumber(patch.tolerance)
+  if (patch.type === 'URLTest' && tolerance !== undefined) {
+    targetGroup.tolerance = tolerance
+  } else {
+    delete targetGroup.tolerance
+  }
+
+  const expectedStatus = patch.expectedStatus?.trim()
+  if (expectedStatus) {
+    targetGroup['expected-status'] = expectedStatus
+  } else {
+    delete targetGroup['expected-status']
+  }
+
+  profile['proxy-groups'] = proxyGroups as unknown as []
+  await setProfileStr(current || 'default', stringifyYaml(profile))
+}

--- a/src/main/utils/ipc.ts
+++ b/src/main/utils/ipc.ts
@@ -44,6 +44,10 @@ import {
   convertMrsRuleset
 } from '../config'
 import {
+  getEditableCurrentProfileProxyGroups,
+  updateCurrentProfileProxyGroup
+} from '../config/proxyGroup'
+import {
   manualGrantCorePermition,
   quitWithoutCore,
   restartCore,
@@ -182,6 +186,13 @@ export function registerIpcMainHandlers(): void {
   ipcMain.handle('getCurrentProfileItem', ipcErrorWrapper(getCurrentProfileItem))
   ipcMain.handle('getProfileItem', (_e, id) => ipcErrorWrapper(getProfileItem)(id))
   ipcMain.handle('getProfileStr', (_e, id) => ipcErrorWrapper(getProfileStr)(id))
+  ipcMain.handle(
+    'getEditableCurrentProfileProxyGroups',
+    ipcErrorWrapper(getEditableCurrentProfileProxyGroups)
+  )
+  ipcMain.handle('updateCurrentProfileProxyGroup', (_e, patch) =>
+    ipcErrorWrapper(updateCurrentProfileProxyGroup)(patch)
+  )
   ipcMain.handle('getFileStr', (_e, path) => ipcErrorWrapper(getFileStr)(path))
   ipcMain.handle('setFileStr', (_e, path, str) => ipcErrorWrapper(setFileStr)(path, str))
   ipcMain.handle('getRuleStr', (_e, path) => ipcErrorWrapper(getRuleStr)(path))

--- a/src/renderer/src/components/proxies/edit-proxy-group-modal.tsx
+++ b/src/renderer/src/components/proxies/edit-proxy-group-modal.tsx
@@ -1,0 +1,632 @@
+import React, { useEffect, useMemo, useState } from 'react'
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from '@renderer/components/ui/dialog'
+import { Button } from '@renderer/components/ui/button'
+import { Input } from '@renderer/components/ui/input'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from '@renderer/components/ui/select'
+import { Switch } from '@renderer/components/ui/switch'
+import { Separator } from '@renderer/components/ui/separator'
+import EditFileModal from '../profiles/edit-file-modal'
+import { toast } from 'sonner'
+import {
+  getEditableCurrentProfileProxyGroups,
+  getProfileConfig,
+  updateCurrentProfileProxyGroup
+} from '@renderer/utils/ipc'
+import {
+  DndContext,
+  closestCenter,
+  DragEndEvent,
+  PointerSensor,
+  useSensor,
+  useSensors
+} from '@dnd-kit/core'
+import { SortableContext, useSortable } from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
+import { cn } from '@renderer/lib/utils'
+import { GripVertical, Info, Plus, Trash2 } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+
+interface Props {
+  groupName: string
+  onClose: () => void
+  onSaved: () => void
+}
+
+interface SortableProxyItemProps {
+  id: string
+  disabled: boolean
+  onRemove: () => void
+}
+
+const parseNonNegativeNumber = (value: string): number | undefined => {
+  if (!value) return undefined
+  const nextValue = parseInt(value)
+  if (Number.isNaN(nextValue)) return undefined
+  return Math.max(0, nextValue)
+}
+
+const SortableProxyItem: React.FC<SortableProxyItemProps> = ({ id, disabled, onRemove }) => {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id,
+    disabled
+  })
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={{
+        transform: CSS.Transform.toString(transform),
+        transition,
+        zIndex: isDragging ? 'calc(infinity)' : undefined
+      }}
+      className={cn(
+        'flex items-center justify-between gap-3 rounded-xl border border-stroke bg-card/40 px-3 py-2',
+        disabled && 'opacity-60'
+      )}
+    >
+      <div className="flex min-w-0 items-center gap-2">
+        <Button
+          size="icon-sm"
+          variant="ghost"
+          className={cn('cursor-grab active:cursor-grabbing', disabled && 'cursor-not-allowed')}
+          disabled={disabled}
+          {...attributes}
+          {...listeners}
+        >
+          <GripVertical className="size-4" />
+        </Button>
+        <span className="truncate text-sm">{id}</span>
+      </div>
+      <Button size="icon-sm" variant="ghost" disabled={disabled} onClick={onRemove}>
+        <Trash2 className="size-4" />
+      </Button>
+    </div>
+  )
+}
+
+const EditProxyGroupModal: React.FC<Props> = ({ groupName, onClose, onSaved }) => {
+  const { t } = useTranslation()
+  const [groupConfig, setGroupConfig] = useState<EditableProxyGroupConfig>()
+  const [currentProfileId, setCurrentProfileId] = useState<string>()
+  const [openProfileYamlEditor, setOpenProfileYamlEditor] = useState(false)
+  const [selectedCandidate, setSelectedCandidate] = useState<string>()
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: {
+        distance: 2
+      }
+    })
+  )
+
+  useEffect(() => {
+    const load = async (): Promise<void> => {
+      setLoading(true)
+      try {
+        const profileConfig = await getProfileConfig()
+        setCurrentProfileId(profileConfig.current || 'default')
+        const groups = await getEditableCurrentProfileProxyGroups()
+        const currentGroup = groups.find((item) => item.name === groupName)
+        if (!currentGroup) {
+          throw new Error(t('proxies.groupEditorNotFound'))
+        }
+        setGroupConfig(currentGroup)
+      } catch (error) {
+        toast.error(`${error}`)
+        onClose()
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    void load()
+  }, [groupName, onClose, t])
+
+  const availableCandidates = useMemo(() => {
+    if (!groupConfig) return []
+    return groupConfig.candidates.filter((candidate) => !groupConfig.proxies.includes(candidate))
+  }, [groupConfig])
+
+  const isHealthCheckType = groupConfig?.type === 'Fallback' || groupConfig?.type === 'URLTest'
+  const isUrlTestType = groupConfig?.type === 'URLTest'
+  const isProviderOnly = groupConfig?.providerOnly ?? false
+  const groupTypeDescriptionKey = useMemo(() => {
+    if (!groupConfig) return 'proxies.groupTypeSelectorDescription'
+
+    switch (groupConfig.type) {
+      case 'Fallback':
+        return 'proxies.groupTypeFallbackDescription'
+      case 'URLTest':
+        return 'proxies.groupTypeUrlTestDescription'
+      default:
+        return 'proxies.groupTypeSelectorDescription'
+    }
+  }, [groupConfig])
+  const proxyListTitleKey = useMemo(() => {
+    if (!groupConfig) return 'proxies.groupEditorProxyListTitleSelector'
+
+    switch (groupConfig.type) {
+      case 'Fallback':
+        return 'proxies.groupEditorProxyListTitleFallback'
+      case 'URLTest':
+        return 'proxies.groupEditorProxyListTitleUrlTest'
+      default:
+        return 'proxies.groupEditorProxyListTitleSelector'
+    }
+  }, [groupConfig])
+  const proxyListHintKey = useMemo(() => {
+    if (!groupConfig) return 'proxies.groupEditorProxyListHintSelector'
+
+    switch (groupConfig.type) {
+      case 'Fallback':
+        return 'proxies.groupEditorProxyListHintFallback'
+      case 'URLTest':
+        return 'proxies.groupEditorProxyListHintUrlTest'
+      default:
+        return 'proxies.groupEditorProxyListHintSelector'
+    }
+  }, [groupConfig])
+  const emptyProxyListKey = useMemo(() => {
+    if (!groupConfig) return 'proxies.groupEditorEmptySelector'
+
+    switch (groupConfig.type) {
+      case 'Fallback':
+        return 'proxies.groupEditorEmptyFallback'
+      case 'URLTest':
+        return 'proxies.groupEditorEmptyUrlTest'
+      default:
+        return 'proxies.groupEditorEmptySelector'
+    }
+  }, [groupConfig])
+
+  const moveProxy = (fromIndex: number, toIndex: number): void => {
+    if (!groupConfig || fromIndex === toIndex || fromIndex < 0 || toIndex < 0) return
+    const nextProxies = [...groupConfig.proxies]
+    const [movedProxy] = nextProxies.splice(fromIndex, 1)
+    if (!movedProxy) return
+    nextProxies.splice(toIndex, 0, movedProxy)
+    setGroupConfig({ ...groupConfig, proxies: nextProxies })
+  }
+
+  const onDragEnd = (event: DragEndEvent): void => {
+    if (!groupConfig) return
+    const { active, over } = event
+    if (!over || active.id === over.id) return
+    moveProxy(
+      groupConfig.proxies.findIndex((proxy) => proxy === active.id),
+      groupConfig.proxies.findIndex((proxy) => proxy === over.id)
+    )
+  }
+
+  const addCandidate = (): void => {
+    if (!groupConfig || !selectedCandidate) return
+    if (groupConfig.proxies.includes(selectedCandidate)) return
+    setGroupConfig({
+      ...groupConfig,
+      proxies: [...groupConfig.proxies, selectedCandidate]
+    })
+    setSelectedCandidate(undefined)
+  }
+
+  const removeProxy = (proxyName: string): void => {
+    if (!groupConfig) return
+    setGroupConfig({
+      ...groupConfig,
+      proxies: groupConfig.proxies.filter((proxy) => proxy !== proxyName)
+    })
+  }
+
+  const save = async (): Promise<void> => {
+    if (!groupConfig) return
+    if (groupConfig.proxies.length === 0) {
+      toast.error(t('proxies.groupEditorRequireProxy'))
+      return
+    }
+
+    setSaving(true)
+    try {
+      await updateCurrentProfileProxyGroup({
+        name: groupConfig.name,
+        type: groupConfig.type,
+        proxies: groupConfig.proxies,
+        url: groupConfig.url,
+        interval: groupConfig.interval,
+        timeout: groupConfig.timeout,
+        lazy: groupConfig.lazy,
+        maxFailedTimes: groupConfig.maxFailedTimes,
+        tolerance: groupConfig.tolerance,
+        expectedStatus: groupConfig.expectedStatus
+      })
+      onSaved()
+      onClose()
+    } catch (error) {
+      toast.error(`${error}`)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <Dialog open={true} onOpenChange={(open) => !open && onClose()}>
+      <DialogContent
+        className="flag-emoji sm:max-w-2xl max-h-[calc(100vh-120px)] flex flex-col min-h-0"
+        showCloseButton={false}
+      >
+        <DialogHeader className="pb-0">
+          <DialogTitle>{t('proxies.groupEditorTitle', { name: groupName })}</DialogTitle>
+        </DialogHeader>
+        {loading || !groupConfig ? (
+          <div className="py-6 text-sm text-muted-foreground">{t('common.loading')}</div>
+        ) : (
+          <div className="py-2 flex flex-col gap-1 overflow-y-auto min-h-0">
+            <div className="rounded-2xl border border-stroke bg-card/40 p-4 space-y-4">
+              <div className="flex items-start justify-between gap-4">
+                <div className="space-y-1">
+                  <div className="text-sm font-medium">{t('proxies.groupEditorType')}</div>
+                  <p className="text-sm text-muted-foreground">
+                    {t('proxies.groupEditorTypeHint')}
+                  </p>
+                </div>
+                <Select
+                  value={groupConfig.type}
+                  disabled={isProviderOnly}
+                  onValueChange={(value) => {
+                    setGroupConfig({
+                      ...groupConfig,
+                      type: value as EditableProxyGroupType
+                    })
+                  }}
+                >
+                  <SelectTrigger size="sm" className="w-44 shrink-0">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent position="popper">
+                    <SelectItem value="Selector">{t('proxies.groupTypeSelector')}</SelectItem>
+                    <SelectItem value="Fallback">{t('proxies.groupTypeFallback')}</SelectItem>
+                    <SelectItem value="URLTest">{t('proxies.groupTypeUrlTest')}</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div className="rounded-xl border border-stroke bg-background/70 p-3">
+                <div className="flex items-start gap-2">
+                  <Info className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+                  <div className="space-y-1 text-sm">
+                    <div className="font-medium">
+                      {groupConfig.type === 'Selector' && t('proxies.groupTypeSelector')}
+                      {groupConfig.type === 'Fallback' && t('proxies.groupTypeFallback')}
+                      {groupConfig.type === 'URLTest' && t('proxies.groupTypeUrlTest')}
+                    </div>
+                    <p className="text-muted-foreground">{t(groupTypeDescriptionKey)}</p>
+                    <p className="text-muted-foreground">{t('proxies.groupEditorSaveHint')}</p>
+                  </div>
+                </div>
+              </div>
+
+              {isProviderOnly && (
+                <div className="rounded-xl border border-amber-500/30 bg-amber-500/10 p-3">
+                  <div className="flex items-start justify-between gap-3">
+                    <p className="text-sm text-muted-foreground">
+                      {t('proxies.groupEditorProviderOnlyWarning', {
+                        providers: groupConfig.providers.join(', ')
+                      })}
+                    </p>
+                    <Button
+                      size="sm"
+                      variant="secondary"
+                      className="shrink-0"
+                      disabled={!currentProfileId}
+                      onClick={() => setOpenProfileYamlEditor(true)}
+                    >
+                      {t('proxies.groupEditorOpenYaml')}
+                    </Button>
+                  </div>
+                </div>
+              )}
+
+              {isHealthCheckType && (
+                <div className="rounded-xl border border-primary/20 bg-primary/5 p-4 space-y-3">
+                  <div className="space-y-1">
+                    <div className="text-sm font-medium">
+                      {t('proxies.groupEditorHealthSection')}
+                    </div>
+                    <p className="text-sm text-muted-foreground">
+                      {t('proxies.groupEditorHealthSectionHint')}
+                    </p>
+                  </div>
+
+                  <div className="grid gap-3 md:grid-cols-2">
+                    <div className="space-y-1.5">
+                      <div className="text-sm font-medium">{t('proxies.groupEditorTestUrl')}</div>
+                      <Input
+                        className="h-8"
+                        disabled={isProviderOnly || saving}
+                        value={groupConfig.url ?? ''}
+                        placeholder={t('proxies.groupEditorTestUrlPlaceholder')}
+                        onChange={(event) => {
+                          setGroupConfig({ ...groupConfig, url: event.target.value })
+                        }}
+                      />
+                      <p className="text-xs text-muted-foreground">
+                        {t('proxies.groupEditorTestUrlHint')}
+                      </p>
+                    </div>
+
+                    <div className="space-y-1.5">
+                      <div className="text-sm font-medium">
+                        {t('proxies.groupEditorInterval')}
+                        <span className="ml-1 text-muted-foreground">
+                          {t('proxies.groupEditorSecondsUnit')}
+                        </span>
+                      </div>
+                      <Input
+                        type="number"
+                        min={0}
+                        step={1}
+                        inputMode="numeric"
+                        className="h-8"
+                        disabled={isProviderOnly || saving}
+                        value={groupConfig.interval?.toString() ?? ''}
+                        placeholder={t('proxies.groupEditorIntervalPlaceholder')}
+                        onChange={(event) => {
+                          setGroupConfig({
+                            ...groupConfig,
+                            interval: parseNonNegativeNumber(event.target.value)
+                          })
+                        }}
+                      />
+                      <p className="text-xs text-muted-foreground">
+                        {t('proxies.groupEditorIntervalHint')}
+                      </p>
+                    </div>
+
+                    <div className="space-y-1.5">
+                      <div className="text-sm font-medium">
+                        {t('proxies.groupEditorTimeout')}
+                        <span className="ml-1 text-muted-foreground">
+                          {t('proxies.groupEditorMillisecondsUnit')}
+                        </span>
+                      </div>
+                      <Input
+                        type="number"
+                        min={0}
+                        step={1}
+                        inputMode="numeric"
+                        className="h-8"
+                        disabled={isProviderOnly || saving}
+                        value={groupConfig.timeout?.toString() ?? ''}
+                        placeholder={t('proxies.groupEditorTimeoutPlaceholder')}
+                        onChange={(event) => {
+                          setGroupConfig({
+                            ...groupConfig,
+                            timeout: parseNonNegativeNumber(event.target.value)
+                          })
+                        }}
+                      />
+                      <p className="text-xs text-muted-foreground">
+                        {t('proxies.groupEditorTimeoutHint')}
+                      </p>
+                    </div>
+
+                    <div className="space-y-1.5">
+                      <div className="text-sm font-medium">
+                        {t('proxies.groupEditorMaxFailedTimes')}
+                      </div>
+                      <Input
+                        type="number"
+                        min={0}
+                        step={1}
+                        inputMode="numeric"
+                        className="h-8"
+                        disabled={isProviderOnly || saving}
+                        value={groupConfig.maxFailedTimes?.toString() ?? ''}
+                        placeholder={t('proxies.groupEditorMaxFailedTimesPlaceholder')}
+                        onChange={(event) => {
+                          setGroupConfig({
+                            ...groupConfig,
+                            maxFailedTimes: parseNonNegativeNumber(event.target.value)
+                          })
+                        }}
+                      />
+                      <p className="text-xs text-muted-foreground">
+                        {t('proxies.groupEditorMaxFailedTimesHint')}
+                      </p>
+                    </div>
+
+                    {isUrlTestType && (
+                      <>
+                        <div className="space-y-1.5">
+                          <div className="text-sm font-medium">
+                            {t('proxies.groupEditorTolerance')}
+                            <span className="ml-1 text-muted-foreground">
+                              {t('proxies.groupEditorMillisecondsUnit')}
+                            </span>
+                          </div>
+                          <Input
+                            type="number"
+                            min={0}
+                            step={1}
+                            inputMode="numeric"
+                            className="h-8"
+                            disabled={isProviderOnly || saving}
+                            value={groupConfig.tolerance?.toString() ?? ''}
+                            placeholder={t('proxies.groupEditorTolerancePlaceholder')}
+                            onChange={(event) => {
+                              setGroupConfig({
+                                ...groupConfig,
+                                tolerance: parseNonNegativeNumber(event.target.value)
+                              })
+                            }}
+                          />
+                          <p className="text-xs text-muted-foreground">
+                            {t('proxies.groupEditorToleranceHint')}
+                          </p>
+                        </div>
+
+                        <div className="space-y-1.5">
+                          <div className="text-sm font-medium">
+                            {t('proxies.groupEditorExpectedStatus')}
+                          </div>
+                          <Input
+                            className="h-8"
+                            disabled={isProviderOnly || saving}
+                            value={groupConfig.expectedStatus ?? ''}
+                            placeholder={t('proxies.groupEditorExpectedStatusPlaceholder')}
+                            onChange={(event) => {
+                              setGroupConfig({
+                                ...groupConfig,
+                                expectedStatus: event.target.value
+                              })
+                            }}
+                          />
+                          <p className="text-xs text-muted-foreground">
+                            {t('proxies.groupEditorExpectedStatusHint')}
+                          </p>
+                        </div>
+                      </>
+                    )}
+                  </div>
+
+                  <div className="flex items-center justify-between gap-4 rounded-xl border border-stroke bg-background/70 px-3 py-2">
+                    <div className="space-y-0.5">
+                      <div className="text-sm font-medium">{t('proxies.groupEditorLazy')}</div>
+                      <p className="text-sm text-muted-foreground">
+                        {t('proxies.groupEditorLazyHint')}
+                      </p>
+                    </div>
+                    <Switch
+                      disabled={isProviderOnly || saving}
+                      checked={groupConfig.lazy ?? false}
+                      onCheckedChange={(value) => {
+                        setGroupConfig({ ...groupConfig, lazy: value })
+                      }}
+                    />
+                  </div>
+                </div>
+              )}
+            </div>
+
+            {groupConfig.usesProviders && (
+              <div className="rounded-xl border border-stroke bg-card/40 px-3 py-2 text-sm text-muted-foreground">
+                {t('proxies.groupEditorProviderWarning', {
+                  providers: groupConfig.providers.join(', ')
+                })}
+              </div>
+            )}
+
+            <div className="space-y-3">
+              <div className="space-y-2">
+                <div className="text-md leading-8">{t(proxyListTitleKey)}</div>
+                <p className="text-sm text-muted-foreground">{t(proxyListHintKey)}</p>
+                <div className="flex w-full items-center gap-2">
+                <Select
+                  value={selectedCandidate}
+                  disabled={isProviderOnly || saving}
+                  onValueChange={setSelectedCandidate}
+                >
+                  <SelectTrigger size="sm" className="min-w-0 flex-1">
+                    <SelectValue placeholder={t('proxies.groupEditorAddNode')} />
+                  </SelectTrigger>
+                  <SelectContent position="popper">
+                    {availableCandidates.map((candidate) => (
+                      <SelectItem key={candidate} value={candidate}>
+                        {candidate}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <Button
+                  size="sm"
+                  disabled={!selectedCandidate || isProviderOnly || saving}
+                  className="shrink-0"
+                  onClick={addCandidate}
+                >
+                  <Plus className="size-4" />
+                  {t('common.add')}
+                </Button>
+                </div>
+              </div>
+              <Separator />
+            </div>
+
+            <div className="space-y-2 pb-2">
+              {groupConfig.proxies.length === 0 ? (
+                <div className="rounded-xl border border-dashed border-stroke px-3 py-4 text-sm text-muted-foreground">
+                  {t(emptyProxyListKey)}
+                </div>
+              ) : (
+                <DndContext
+                  sensors={sensors}
+                  collisionDetection={closestCenter}
+                  onDragEnd={onDragEnd}
+                >
+                  <SortableContext items={groupConfig.proxies}>
+                    <div className="space-y-2">
+                      {groupConfig.proxies.map((proxy) => (
+                        <SortableProxyItem
+                          key={proxy}
+                          id={proxy}
+                          disabled={saving || isProviderOnly}
+                          onRemove={() => removeProxy(proxy)}
+                        />
+                      ))}
+                    </div>
+                  </SortableContext>
+                </DndContext>
+              )}
+            </div>
+          </div>
+        )}
+      <DialogFooter>
+          <DialogClose asChild>
+            <Button size="sm" variant="ghost" disabled={saving}>
+              {t('common.cancel')}
+            </Button>
+          </DialogClose>
+          <Button
+            size="sm"
+            disabled={loading || saving || !groupConfig || isProviderOnly}
+            onClick={() => void save()}
+          >
+            {t('common.save')}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+      {openProfileYamlEditor && currentProfileId && (
+        <EditFileModal
+          id={currentProfileId}
+          onClose={() => {
+            setOpenProfileYamlEditor(false)
+            void (async () => {
+              try {
+                const groups = await getEditableCurrentProfileProxyGroups()
+                const currentGroup = groups.find((item) => item.name === groupName)
+                if (currentGroup) {
+                  setGroupConfig(currentGroup)
+                }
+              } catch {
+                // ignore refresh failure, modal already has existing state
+              }
+            })()
+          }}
+        />
+      )}
+    </Dialog>
+  )
+}
+
+export default EditProxyGroupModal

--- a/src/renderer/src/components/proxies/edit-proxy-group-modal.tsx
+++ b/src/renderer/src/components/proxies/edit-proxy-group-modal.tsx
@@ -143,6 +143,7 @@ const EditProxyGroupModal: React.FC<Props> = ({ groupName, onClose, onSaved }) =
 
   const isHealthCheckType = groupConfig?.type === 'Fallback' || groupConfig?.type === 'URLTest'
   const isUrlTestType = groupConfig?.type === 'URLTest'
+  const isSelectorType = groupConfig?.type === 'Selector'
   const isProviderOnly = groupConfig?.providerOnly ?? false
   const groupTypeDescriptionKey = useMemo(() => {
     if (!groupConfig) return 'proxies.groupTypeSelectorDescription'
@@ -528,67 +529,71 @@ const EditProxyGroupModal: React.FC<Props> = ({ groupName, onClose, onSaved }) =
               </div>
             )}
 
-            <div className="space-y-3">
-              <div className="space-y-2">
-                <div className="text-md leading-8">{t(proxyListTitleKey)}</div>
-                <p className="text-sm text-muted-foreground">{t(proxyListHintKey)}</p>
-                <div className="flex w-full items-center gap-2">
-                <Select
-                  value={selectedCandidate}
-                  disabled={isProviderOnly || saving}
-                  onValueChange={setSelectedCandidate}
-                >
-                  <SelectTrigger size="sm" className="min-w-0 flex-1">
-                    <SelectValue placeholder={t('proxies.groupEditorAddNode')} />
-                  </SelectTrigger>
-                  <SelectContent position="popper">
-                    {availableCandidates.map((candidate) => (
-                      <SelectItem key={candidate} value={candidate}>
-                        {candidate}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-                <Button
-                  size="sm"
-                  disabled={!selectedCandidate || isProviderOnly || saving}
-                  className="shrink-0"
-                  onClick={addCandidate}
-                >
-                  <Plus className="size-4" />
-                  {t('common.add')}
-                </Button>
+            {!isSelectorType && (
+              <div className="space-y-3">
+                <div className="space-y-2">
+                  <div className="text-md leading-8">{t(proxyListTitleKey)}</div>
+                  <p className="text-sm text-muted-foreground">{t(proxyListHintKey)}</p>
+                  <div className="flex w-full items-center gap-2">
+                    <Select
+                      value={selectedCandidate}
+                      disabled={isProviderOnly || saving}
+                      onValueChange={setSelectedCandidate}
+                    >
+                      <SelectTrigger size="sm" className="min-w-0 flex-1">
+                        <SelectValue placeholder={t('proxies.groupEditorAddNode')} />
+                      </SelectTrigger>
+                      <SelectContent position="popper">
+                        {availableCandidates.map((candidate) => (
+                          <SelectItem key={candidate} value={candidate}>
+                            {candidate}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <Button
+                      size="sm"
+                      disabled={!selectedCandidate || isProviderOnly || saving}
+                      className="shrink-0"
+                      onClick={addCandidate}
+                    >
+                      <Plus className="size-4" />
+                      {t('common.add')}
+                    </Button>
+                  </div>
                 </div>
+                <Separator />
               </div>
-              <Separator />
-            </div>
+            )}
 
-            <div className="space-y-2 pb-2">
-              {groupConfig.proxies.length === 0 ? (
-                <div className="rounded-xl border border-dashed border-stroke px-3 py-4 text-sm text-muted-foreground">
-                  {t(emptyProxyListKey)}
-                </div>
-              ) : (
-                <DndContext
-                  sensors={sensors}
-                  collisionDetection={closestCenter}
-                  onDragEnd={onDragEnd}
-                >
-                  <SortableContext items={groupConfig.proxies}>
-                    <div className="space-y-2">
-                      {groupConfig.proxies.map((proxy) => (
-                        <SortableProxyItem
-                          key={proxy}
-                          id={proxy}
-                          disabled={saving || isProviderOnly}
-                          onRemove={() => removeProxy(proxy)}
-                        />
-                      ))}
-                    </div>
-                  </SortableContext>
-                </DndContext>
-              )}
-            </div>
+            {!isSelectorType && (
+              <div className="space-y-2 pb-2">
+                {groupConfig.proxies.length === 0 ? (
+                  <div className="rounded-xl border border-dashed border-stroke px-3 py-4 text-sm text-muted-foreground">
+                    {t(emptyProxyListKey)}
+                  </div>
+                ) : (
+                  <DndContext
+                    sensors={sensors}
+                    collisionDetection={closestCenter}
+                    onDragEnd={onDragEnd}
+                  >
+                    <SortableContext items={groupConfig.proxies}>
+                      <div className="space-y-2">
+                        {groupConfig.proxies.map((proxy) => (
+                          <SortableProxyItem
+                            key={proxy}
+                            id={proxy}
+                            disabled={saving || isProviderOnly}
+                            onRemove={() => removeProxy(proxy)}
+                          />
+                        ))}
+                      </div>
+                    </SortableContext>
+                  </DndContext>
+                )}
+              </div>
+            )}
           </div>
         )}
       <DialogFooter>

--- a/src/renderer/src/locales/en-US/index.ts
+++ b/src/renderer/src/locales/en-US/index.ts
@@ -882,7 +882,8 @@ export default {
     groupEditorTitle: 'Edit {{name}}',
     groupEditorNotFound: 'Proxy group configuration not found',
     groupEditorType: 'Group type',
-    groupEditorTypeHint: 'Choose how Mihomo should use and switch between the proxies in this group.',
+    groupEditorTypeHint:
+      'This configures the Mihomo group behavior itself. The current proxy for Selector is still chosen on the Proxies page.',
     groupEditorSaveHint: 'Changes take effect after you save this group.',
     groupEditorHealthSection: 'Health check behavior',
     groupEditorHealthSectionHint:
@@ -937,7 +938,7 @@ export default {
       'Optional HTTP status matcher for health checks, for example 204 or 2xx.',
     groupTypeSelector: 'Selector',
     groupTypeSelectorDescription:
-      'Manual mode. Mihomo will use the proxy you choose for this group and will not automatically switch to another one.',
+      'Manual mode. The active proxy for this group is chosen on the Proxies page. Here you can keep the group manual or switch it to Fallback / URL Test.',
     groupTypeFallback: 'Fallback',
     groupTypeFallbackDescription:
       'Failover mode. Mihomo checks proxies in the order below and uses the first available one.',

--- a/src/renderer/src/locales/en-US/index.ts
+++ b/src/renderer/src/locales/en-US/index.ts
@@ -877,7 +877,73 @@ export default {
     delayTestTimeoutPlaceholder: 'Default: 5000',
     delayTest: 'Test',
     timeout: 'Timeout',
-    unpin: 'Unpin'
+    unpin: 'Unpin',
+    groupEditorOpen: 'Edit group',
+    groupEditorTitle: 'Edit {{name}}',
+    groupEditorNotFound: 'Proxy group configuration not found',
+    groupEditorType: 'Group type',
+    groupEditorTypeHint: 'Choose how Mihomo should use and switch between the proxies in this group.',
+    groupEditorSaveHint: 'Changes take effect after you save this group.',
+    groupEditorHealthSection: 'Health check behavior',
+    groupEditorHealthSectionHint:
+      'These settings control how Mihomo checks proxies before switching or choosing one automatically.',
+    groupEditorSecondsUnit: '(seconds)',
+    groupEditorMillisecondsUnit: '(ms)',
+    groupEditorOrder: 'Proxy order',
+    groupEditorProxyListTitleSelector: 'Available proxies in this group',
+    groupEditorProxyListTitleFallback: 'Failover order',
+    groupEditorProxyListTitleUrlTest: 'Proxies for auto testing',
+    groupEditorProxyListHintSelector:
+      'Selector mode does not switch automatically. The list below only defines which proxies can be chosen manually in this group.',
+    groupEditorProxyListHintFallback:
+      'Mihomo checks proxies from top to bottom and uses the first available one.',
+    groupEditorProxyListHintUrlTest:
+      'Mihomo regularly tests these proxies and chooses the best available result.',
+    groupEditorAddNode: 'Add proxy or DIRECT',
+    groupEditorEmpty: 'No proxies configured for this group.',
+    groupEditorEmptySelector: 'No manually selectable proxies have been added to this group yet.',
+    groupEditorEmptyFallback: 'Add proxies that Mihomo can use for failover.',
+    groupEditorEmptyUrlTest: 'Add proxies that Mihomo can test and compare automatically.',
+    groupEditorRequireProxy: 'Add at least one proxy before saving',
+    groupEditorTestUrl: 'Health check URL',
+    groupEditorTestUrlPlaceholder: 'Example: https://www.gstatic.com/generate_204',
+    groupEditorTestUrlHint:
+      'If left empty, Mihomo will use the group default URL from the configuration.',
+    groupEditorInterval: 'Check interval',
+    groupEditorIntervalPlaceholder: 'Example: 300',
+    groupEditorIntervalHint: 'How often Mihomo should re-check proxy availability.',
+    groupEditorTimeout: 'Timeout',
+    groupEditorTimeoutPlaceholder: 'Optional',
+    groupEditorTimeoutHint: 'How long to wait for a health check response from a proxy.',
+    groupEditorMaxFailedTimes: 'Max failed times',
+    groupEditorMaxFailedTimesPlaceholder: 'Optional',
+    groupEditorMaxFailedTimesHint:
+      'After this many failed checks in a row, Mihomo treats the proxy as unavailable.',
+    groupEditorLazy: 'Lazy checks',
+    groupEditorLazyHint:
+      'Do not pre-check proxies in advance. Start checking only when this group is actually used.',
+    groupEditorProviderWarning:
+      'This group also uses proxy providers ({{providers}}). Mihomo fallback order works with the proxies list below, so provider-only entries may still need manual profile editing.',
+    groupEditorProviderOnlyWarning:
+      'This group is built only from proxy providers ({{providers}}). Mihomo health checks and failover order here apply only to explicit proxies entries, so change this group in the profile YAML instead.',
+    groupEditorOpenYaml: 'Open YAML',
+    groupEditorTolerance: 'Tolerance',
+    groupEditorTolerancePlaceholder: 'Optional',
+    groupEditorToleranceHint:
+      'Only for URL Test. Small delay differences within this value are treated as equivalent.',
+    groupEditorExpectedStatus: 'Expected status',
+    groupEditorExpectedStatusPlaceholder: 'Optional, for example: 204',
+    groupEditorExpectedStatusHint:
+      'Optional HTTP status matcher for health checks, for example 204 or 2xx.',
+    groupTypeSelector: 'Selector',
+    groupTypeSelectorDescription:
+      'Manual mode. Mihomo will use the proxy you choose for this group and will not automatically switch to another one.',
+    groupTypeFallback: 'Fallback',
+    groupTypeFallbackDescription:
+      'Failover mode. Mihomo checks proxies in the order below and uses the first available one.',
+    groupTypeUrlTest: 'URL Test',
+    groupTypeUrlTestDescription:
+      'Auto-test mode. Mihomo regularly checks proxies and prefers the best available result instead of a fixed order.'
   },
 
   sysproxy: {

--- a/src/renderer/src/locales/ru-RU/index.ts
+++ b/src/renderer/src/locales/ru-RU/index.ts
@@ -877,7 +877,73 @@ export default {
     delayTestTimeoutPlaceholder: 'По умолчанию: 5000',
     delayTest: 'Тест',
     timeout: 'Тайм-аут',
-    unpin: 'Открепить'
+    unpin: 'Открепить',
+    groupEditorOpen: 'Редактировать группу',
+    groupEditorTitle: 'Редактировать {{name}}',
+    groupEditorNotFound: 'Конфигурация группы прокси не найдена',
+    groupEditorType: 'Режим группы',
+    groupEditorTypeHint: 'Выберите, как Mihomo должен использовать и переключать прокси внутри этой группы.',
+    groupEditorSaveHint: 'Изменения применятся после сохранения группы.',
+    groupEditorHealthSection: 'Проверка доступности',
+    groupEditorHealthSectionHint:
+      'Эти параметры управляют тем, как Mihomo проверяет прокси перед автопереключением или автоматическим выбором.',
+    groupEditorSecondsUnit: '(секунды)',
+    groupEditorMillisecondsUnit: '(мс)',
+    groupEditorOrder: 'Порядок прокси',
+    groupEditorProxyListTitleSelector: 'Доступные прокси в группе',
+    groupEditorProxyListTitleFallback: 'Порядок переключения',
+    groupEditorProxyListTitleUrlTest: 'Прокси для автотеста',
+    groupEditorProxyListHintSelector:
+      'В режиме Selector автопереключения нет. Список ниже определяет, какие прокси можно выбрать вручную в этой группе.',
+    groupEditorProxyListHintFallback:
+      'Mihomo проверяет прокси сверху вниз и использует первый доступный.',
+    groupEditorProxyListHintUrlTest:
+      'Mihomo регулярно тестирует эти прокси и выбирает лучший доступный вариант.',
+    groupEditorAddNode: 'Добавить прокси или DIRECT',
+    groupEditorEmpty: 'В этой группе пока нет прокси.',
+    groupEditorEmptySelector: 'В этой группе пока нет доступных для ручного выбора прокси.',
+    groupEditorEmptyFallback: 'Добавьте прокси для резервного переключения.',
+    groupEditorEmptyUrlTest: 'Добавьте прокси, которые Mihomo сможет тестировать автоматически.',
+    groupEditorRequireProxy: 'Перед сохранением добавьте хотя бы один прокси',
+    groupEditorTestUrl: 'URL для проверки доступности',
+    groupEditorTestUrlPlaceholder: 'Например: https://www.gstatic.com/generate_204',
+    groupEditorTestUrlHint:
+      'Если оставить пустым, Mihomo использует URL по умолчанию из конфигурации группы.',
+    groupEditorInterval: 'Интервал проверки',
+    groupEditorIntervalPlaceholder: 'Например: 300',
+    groupEditorIntervalHint: 'Как часто Mihomo должен перепроверять доступность прокси.',
+    groupEditorTimeout: 'Тайм-аут',
+    groupEditorTimeoutPlaceholder: 'Необязательно',
+    groupEditorTimeoutHint: 'Сколько ждать ответа от прокси во время проверки.',
+    groupEditorMaxFailedTimes: 'Максимум неудачных проверок',
+    groupEditorMaxFailedTimesPlaceholder: 'Необязательно',
+    groupEditorMaxFailedTimesHint:
+      'После этого числа подряд неудачных проверок прокси считается недоступным.',
+    groupEditorLazy: 'Ленивые проверки',
+    groupEditorLazyHint:
+      'Не проверять прокси заранее, а начинать проверки только когда эта группа реально используется.',
+    groupEditorProviderWarning:
+      'Эта группа также использует proxy providers ({{providers}}). Порядок fallback в mihomo работает по списку proxies ниже, поэтому для provider-only записей может понадобиться ручное редактирование профиля.',
+    groupEditorProviderOnlyWarning:
+      'Эта группа построена только на proxy providers ({{providers}}). В Mihomo проверка доступности и порядок failover здесь применяются только к явному списку proxies, поэтому такую группу лучше менять через YAML профиля.',
+    groupEditorOpenYaml: 'Открыть YAML',
+    groupEditorTolerance: 'Допуск',
+    groupEditorTolerancePlaceholder: 'Необязательно',
+    groupEditorToleranceHint:
+      'Только для URL Test. Небольшие различия в задержке в пределах этого значения считаются одинаковыми.',
+    groupEditorExpectedStatus: 'Ожидаемый статус',
+    groupEditorExpectedStatusPlaceholder: 'Необязательно, например: 204',
+    groupEditorExpectedStatusHint:
+      'Необязательный HTTP-статус для проверки доступности, например 204 или 2xx.',
+    groupTypeSelector: 'Selector',
+    groupTypeSelectorDescription:
+      'Ручной режим. Mihomo будет использовать выбранный вами прокси и не станет автоматически переключаться на другой.',
+    groupTypeFallback: 'Fallback',
+    groupTypeFallbackDescription:
+      'Режим резервирования. Mihomo проверяет прокси в порядке ниже и использует первый доступный.',
+    groupTypeUrlTest: 'URL Test',
+    groupTypeUrlTestDescription:
+      'Режим автотеста. Mihomo регулярно проверяет прокси и выбирает лучший доступный вариант, а не фиксированный порядок.'
   },
 
   sysproxy: {

--- a/src/renderer/src/locales/ru-RU/index.ts
+++ b/src/renderer/src/locales/ru-RU/index.ts
@@ -882,7 +882,8 @@ export default {
     groupEditorTitle: 'Редактировать {{name}}',
     groupEditorNotFound: 'Конфигурация группы прокси не найдена',
     groupEditorType: 'Режим группы',
-    groupEditorTypeHint: 'Выберите, как Mihomo должен использовать и переключать прокси внутри этой группы.',
+    groupEditorTypeHint:
+      'Здесь настраивается поведение самой группы Mihomo. Выбор текущего узла для Selector по-прежнему делается на странице Proxies.',
     groupEditorSaveHint: 'Изменения применятся после сохранения группы.',
     groupEditorHealthSection: 'Проверка доступности',
     groupEditorHealthSectionHint:
@@ -937,7 +938,7 @@ export default {
       'Необязательный HTTP-статус для проверки доступности, например 204 или 2xx.',
     groupTypeSelector: 'Selector',
     groupTypeSelectorDescription:
-      'Ручной режим. Mihomo будет использовать выбранный вами прокси и не станет автоматически переключаться на другой.',
+      'Ручной режим. Активный прокси для такой группы выбирается на странице Proxies. Здесь можно только оставить группу в ручном режиме или переключить её на Fallback / URL Test.',
     groupTypeFallback: 'Fallback',
     groupTypeFallbackDescription:
       'Режим резервирования. Mihomo проверяет прокси в порядке ниже и использует первый доступный.',

--- a/src/renderer/src/locales/zh-CN/index.ts
+++ b/src/renderer/src/locales/zh-CN/index.ts
@@ -939,7 +939,8 @@ export default {
     groupEditorTitle: '编辑 {{name}}',
     groupEditorNotFound: '未找到代理组配置',
     groupEditorType: '分组类型',
-    groupEditorTypeHint: '选择 Mihomo 在这个分组里如何使用和切换代理。',
+    groupEditorTypeHint:
+      '这里配置的是 Mihomo 分组本身的行为。Selector 的当前节点仍然是在 Proxies 页面里选择的。',
     groupEditorSaveHint: '保存分组后更改才会生效。',
     groupEditorHealthSection: '健康检查行为',
     groupEditorHealthSectionHint: '这些参数控制 Mihomo 在自动切换或自动选择前如何检查代理。',
@@ -988,7 +989,7 @@ export default {
     groupEditorExpectedStatusHint: '可选的健康检查 HTTP 状态匹配，例如 204 或 2xx。',
     groupTypeSelector: 'Selector',
     groupTypeSelectorDescription:
-      '手动模式。Mihomo 会使用你为该分组选中的代理，不会自动切换到其他代理。',
+      '手动模式。这个分组的当前代理仍然是在 Proxies 页面里选择的。这里可以保持手动模式，或者切换成 Fallback / URL Test。',
     groupTypeFallback: 'Fallback',
     groupTypeFallbackDescription:
       '故障转移模式。Mihomo 会按下面的顺序检查代理，并使用第一个可用的代理。',

--- a/src/renderer/src/locales/zh-CN/index.ts
+++ b/src/renderer/src/locales/zh-CN/index.ts
@@ -934,7 +934,67 @@ export default {
     delayTestTimeoutPlaceholder: '默认 5000',
     delayTest: '测试',
     timeout: '超时',
-    unpin: '取消固定'
+    unpin: '取消固定',
+    groupEditorOpen: '编辑分组',
+    groupEditorTitle: '编辑 {{name}}',
+    groupEditorNotFound: '未找到代理组配置',
+    groupEditorType: '分组类型',
+    groupEditorTypeHint: '选择 Mihomo 在这个分组里如何使用和切换代理。',
+    groupEditorSaveHint: '保存分组后更改才会生效。',
+    groupEditorHealthSection: '健康检查行为',
+    groupEditorHealthSectionHint: '这些参数控制 Mihomo 在自动切换或自动选择前如何检查代理。',
+    groupEditorSecondsUnit: '（秒）',
+    groupEditorMillisecondsUnit: '（毫秒）',
+    groupEditorOrder: '代理顺序',
+    groupEditorProxyListTitleSelector: '分组中的可选代理',
+    groupEditorProxyListTitleFallback: '故障转移顺序',
+    groupEditorProxyListTitleUrlTest: '自动测试代理',
+    groupEditorProxyListHintSelector:
+      'Selector 模式不会自动切换。下面的列表只决定这个分组里哪些代理可以手动选择。',
+    groupEditorProxyListHintFallback:
+      'Mihomo 会按从上到下的顺序检查代理，并使用第一个可用的代理。',
+    groupEditorProxyListHintUrlTest:
+      'Mihomo 会定期测试这些代理，并选择当前表现最好的可用结果。',
+    groupEditorAddNode: '添加代理或 DIRECT',
+    groupEditorEmpty: '该分组尚未配置代理。',
+    groupEditorEmptySelector: '这个分组里还没有可供手动选择的代理。',
+    groupEditorEmptyFallback: '添加可供 Mihomo 故障转移使用的代理。',
+    groupEditorEmptyUrlTest: '添加可供 Mihomo 自动测试和比较的代理。',
+    groupEditorRequireProxy: '保存前至少添加一个代理',
+    groupEditorTestUrl: '健康检查 URL',
+    groupEditorTestUrlPlaceholder: '例如：https://www.gstatic.com/generate_204',
+    groupEditorTestUrlHint: '如果留空，Mihomo 将使用该分组配置里的默认 URL。',
+    groupEditorInterval: '检查间隔',
+    groupEditorIntervalPlaceholder: '例如：300',
+    groupEditorIntervalHint: 'Mihomo 重新检查代理可用性的频率。',
+    groupEditorTimeout: '超时时间',
+    groupEditorTimeoutPlaceholder: '可选',
+    groupEditorTimeoutHint: '健康检查时等待代理响应的时间。',
+    groupEditorMaxFailedTimes: '最大失败次数',
+    groupEditorMaxFailedTimesPlaceholder: '可选',
+    groupEditorMaxFailedTimesHint: '连续失败达到这个次数后，Mihomo 会把代理视为不可用。',
+    groupEditorLazy: '惰性检查',
+    groupEditorLazyHint: '不提前检查代理，只有在这个分组实际被使用时才开始检查。',
+    groupEditorProviderWarning:
+      '该分组同时使用了 proxy providers（{{providers}}）。mihomo 的 fallback 顺序只会按下面的 proxies 列表工作，因此纯 provider 条目可能仍需手动编辑配置文件。',
+    groupEditorProviderOnlyWarning:
+      '该分组完全由 proxy providers（{{providers}}）构成。Mihomo 这里的健康检查和故障转移顺序只作用于显式的 proxies 列表，因此这类分组更适合直接编辑配置 YAML。',
+    groupEditorOpenYaml: '打开 YAML',
+    groupEditorTolerance: '容差',
+    groupEditorTolerancePlaceholder: '可选',
+    groupEditorToleranceHint: '仅用于 URL Test。延迟差异在这个值以内时会被视为相近。',
+    groupEditorExpectedStatus: '期望状态码',
+    groupEditorExpectedStatusPlaceholder: '可选，例如：204',
+    groupEditorExpectedStatusHint: '可选的健康检查 HTTP 状态匹配，例如 204 或 2xx。',
+    groupTypeSelector: 'Selector',
+    groupTypeSelectorDescription:
+      '手动模式。Mihomo 会使用你为该分组选中的代理，不会自动切换到其他代理。',
+    groupTypeFallback: 'Fallback',
+    groupTypeFallbackDescription:
+      '故障转移模式。Mihomo 会按下面的顺序检查代理，并使用第一个可用的代理。',
+    groupTypeUrlTest: 'URL Test',
+    groupTypeUrlTestDescription:
+      '自动测试模式。Mihomo 会定期检查代理，并优先选择当前表现最好的可用代理，而不是固定顺序。'
   },
 
   sysproxy: {

--- a/src/renderer/src/pages/proxies.tsx
+++ b/src/renderer/src/pages/proxies.tsx
@@ -16,6 +16,7 @@ import { useLocation } from 'react-router-dom'
 import { GroupedVirtuoso, GroupedVirtuosoHandle } from 'react-virtuoso'
 import ProxyItem from '@renderer/components/proxies/proxy-item'
 import ProxySettingModal from '@renderer/components/proxies/proxy-setting-modal'
+import EditProxyGroupModal from '@renderer/components/proxies/edit-proxy-group-modal'
 import { useGroups } from '@renderer/hooks/use-groups'
 import CollapseInput from '@renderer/components/base/collapse-input'
 import { includesIgnoreCase } from '@renderer/utils/includes'
@@ -28,6 +29,7 @@ import {
   ChevronsUpDown,
   Gauge,
   LocateFixed,
+  Pencil,
   SlidersHorizontal
 } from 'lucide-react'
 
@@ -61,6 +63,7 @@ const Proxies: React.FC = () => {
   const [delaying, setDelaying] = useState(Array(groups.length).fill(false))
   const [searchValue, setSearchValue] = useState(Array(groups.length).fill(''))
   const [isSettingModalOpen, setIsSettingModalOpen] = useState(false)
+  const [editingGroupName, setEditingGroupName] = useState<string>()
   const virtuosoRef = useRef<GroupedVirtuosoHandle>(null)
   const { groupCounts, allProxies } = useMemo(() => {
     const groupCounts: number[] = []
@@ -312,6 +315,16 @@ const Proxies: React.FC = () => {
                       value={searchValue[index]}
                       onValueChange={(v) => updateSearchValue(index, v)}
                     />
+                    {['Selector', 'Fallback', 'URLTest'].includes(group.type) && (
+                      <Button
+                        title={t('proxies.groupEditorOpen')}
+                        variant="ghost"
+                        size="icon-sm"
+                        onClick={() => setEditingGroupName(group.name)}
+                      >
+                        <Pencil className="text-base" />
+                      </Button>
+                    )}
                     <Button
                       title={t('sider.locateCurrentNode')}
                       variant="ghost"
@@ -444,6 +457,15 @@ const Proxies: React.FC = () => {
       }
     >
       {isSettingModalOpen && <ProxySettingModal onClose={() => setIsSettingModalOpen(false)} />}
+      {editingGroupName && (
+        <EditProxyGroupModal
+          groupName={editingGroupName}
+          onClose={() => setEditingGroupName(undefined)}
+          onSaved={() => {
+            mutate()
+          }}
+        />
+      )}
       {mode === 'direct' ? (
         <div className="h-full w-full flex justify-center items-center">
           <div className="flex flex-col items-center gap-3">

--- a/src/renderer/src/utils/ipc.ts
+++ b/src/renderer/src/utils/ipc.ts
@@ -167,6 +167,18 @@ export async function getProfileStr(id: string): Promise<string> {
   return ipcErrorWrapper(await window.electron.ipcRenderer.invoke('getProfileStr', id))
 }
 
+export async function getEditableCurrentProfileProxyGroups(): Promise<EditableProxyGroupConfig[]> {
+  return ipcErrorWrapper(
+    await window.electron.ipcRenderer.invoke('getEditableCurrentProfileProxyGroups')
+  )
+}
+
+export async function updateCurrentProfileProxyGroup(
+  patch: EditableProxyGroupPatch
+): Promise<void> {
+  return ipcErrorWrapper(await window.electron.ipcRenderer.invoke('updateCurrentProfileProxyGroup', patch))
+}
+
 export async function getFileStr(id: string): Promise<string> {
   return ipcErrorWrapper(await window.electron.ipcRenderer.invoke('getFileStr', id))
 }

--- a/src/shared/types/types.d.ts
+++ b/src/shared/types/types.d.ts
@@ -45,6 +45,7 @@ type FindProcessMode = 'off' | 'strict' | 'always'
 type DnsMode = 'normal' | 'fake-ip' | 'redir-host'
 type FilterMode = 'blacklist' | 'whitelist'
 type NetworkInterfaceInfo = os.NetworkInterfaceInfo
+type EditableProxyGroupType = 'Selector' | 'Fallback' | 'URLTest'
 type Fingerprints =
   | ''
   | 'random'
@@ -62,3 +63,33 @@ type Fingerprints =
   | 'edge'
   | '360'
   | 'qq'
+
+interface EditableProxyGroupConfig {
+  name: string
+  type: EditableProxyGroupType
+  proxies: string[]
+  candidates: string[]
+  usesProviders: boolean
+  providerOnly: boolean
+  providers: string[]
+  url?: string
+  interval?: number
+  timeout?: number
+  lazy?: boolean
+  maxFailedTimes?: number
+  tolerance?: number
+  expectedStatus?: string
+}
+
+interface EditableProxyGroupPatch {
+  name: string
+  type: EditableProxyGroupType
+  proxies: string[]
+  url?: string
+  interval?: number
+  timeout?: number
+  lazy?: boolean
+  maxFailedTimes?: number
+  tolerance?: number
+  expectedStatus?: string
+}


### PR DESCRIPTION
### Summary
This PR adds a UI editor for built-in Mihomo proxy group behavior instead of implementing client-side failover logic.

### What changed
- added an edit action for editable proxy groups on the Proxies page
- added a proxy group editor modal for `Selector`, `Fallback`, and `URL Test`
- added main-process APIs to read and update `proxy-groups` in the current Mihomo profile
- saving changes updates the profile YAML and applies them through the existing core restart flow for the active profile
- added support for editing built-in Mihomo group fields:
  - `type`
  - `proxies`
  - `url`
  - `interval`
  - `timeout`
  - `max-failed-times`
  - `lazy`
  - `tolerance`
  - `expected-status`
- added drag-and-drop proxy ordering inside the group editor
- improved the modal UX with mode-specific explanations and labels:
  - `Selector` is treated as a group mode editor, not as a second place to pick the active proxy
  - `Fallback` explains top-to-bottom failover order
  - `URL Test` explains automatic testing and best-node selection
- when `Selector` is selected, proxy ordering controls are hidden to avoid duplicating the existing manual node selection flow on the Proxies page
- added localized strings for all supported application languages
- added provider-aware handling:
  - groups using `proxy-providers` show a warning
  - provider-only groups are switched to a safe read-only mode
  - provider-only groups provide a direct shortcut to open the profile YAML editor

### Why this matches Mihomo behavior
- this PR does not introduce a separate app-level failover engine
- it exposes configuration for Mihomo's built-in `fallback` and `url-test` behavior through the UI
- provider-only limitations are surfaced explicitly instead of simulating unsupported behavior in the client

### Описание
Этот PR добавляет UI-редактор для встроенного поведения proxy groups в Mihomo вместо собственной failover-логики на стороне клиента.

### Что изменено
- добавлено действие редактирования для поддерживаемых proxy groups на странице Proxies
- добавлено modal-окно редактирования групп `Selector`, `Fallback` и `URL Test`
- добавлены main-process API для чтения и изменения `proxy-groups` в текущем профиле Mihomo
- при сохранении изменения записываются в YAML профиля и применяются через уже существующий сценарий перезапуска core для активного профиля
- добавлена поддержка редактирования встроенных полей групп Mihomo:
  - `type`
  - `proxies`
  - `url`
  - `interval`
  - `timeout`
  - `max-failed-times`
  - `lazy`
  - `tolerance`
  - `expected-status`
- добавлена drag-and-drop сортировка прокси внутри редактора группы
- улучшен UX modal-окна с понятными подписями и описаниями для каждого режима:
  - `Selector` используется как настройка режима группы, а не как второе место для выбора активного узла
  - `Fallback` объясняет порядок резервного переключения сверху вниз
  - `URL Test` объясняет автоматическое тестирование и выбор лучшего узла
- если выбран `Selector`, блок с порядком прокси скрывается, чтобы не дублировать уже существующий ручной выбор узла на странице Proxies
- добавлена локализация для всех поддерживаемых языков приложения
- добавлена корректная обработка групп с `proxy-providers`:
  - для групп с `proxy-providers` показывается предупреждение
  - группы, состоящие только из providers, переводятся в безопасный read-only режим
  - для таких групп добавлен прямой переход в YAML editor профиля

### Почему это соответствует логике Mihomo
- PR не добавляет отдельный failover-движок на уровне приложения
- он открывает настройку встроенного поведения `fallback` и `url-test` самого Mihomo через UI
- ограничения provider-only групп явно показаны пользователю, вместо имитации неподдерживаемого поведения в клиенте